### PR TITLE
fix src\transformer\utils\quiz_question\get_numerical_answer when ans…

### DIFF
--- a/src/transformer/events/mod_quiz/question_answered/numerical.php
+++ b/src/transformer/events/mod_quiz/question_answered/numerical.php
@@ -49,6 +49,7 @@ function numerical(array $config, \stdClass $event, \stdClass $questionattempt, 
     [
         'min' => $min,
         'max' => $max,
+        'target' => $target,
     ] = utils\quiz_question\get_numerical_answer($config, $question->id);
     $numanswer = $questionattempt->responsesummary;
 
@@ -68,7 +69,7 @@ function numerical(array $config, \stdClass $event, \stdClass $questionattempt, 
         'result' => [
             'response' => $questionattempt->responsesummary,
             'completion' => $questionattempt->responsesummary !== '',
-            'success' => ($min <= $numanswer && $numanswer <= $max),
+            'success' => is_numeric($numanswer) && ($target == '*' || ($min <= $numanswer && $numanswer <= $max)),
             'extensions' => [
                 'http://learninglocker.net/xapi/cmi/numeric/response' => floatval($questionattempt->responsesummary),
             ],

--- a/src/transformer/utils/quiz_question/get_numerical_answer.php
+++ b/src/transformer/utils/quiz_question/get_numerical_answer.php
@@ -51,9 +51,17 @@ function get_numerical_answer(
             'answer' => $answer->id,
         ]);
     $answernum = reset($answernums);
-    $min = $answer->answer - $answernum->tolerance;
-    $max = $answer->answer + $answernum->tolerance;
     $target = $answer->answer;
+    $min = null;
+    $max = null;
+    // Do not calculate if answer is a wildcart (cloze format)
+    if (is_numeric($target)) {
+      $tolerance = floatval($answernum->tolerance);
+      $target = floatval($target);
+      $min = $target - $tolerance;
+      $max = $target + $tolerance;
+
+    }
     return [
         'min' => $min,
         'max' => $max,


### PR DESCRIPTION
fix src\transformer\utils\quiz_question\get_numerical_answer when right answer is a wildcard "*"

**Description**
- The Cloze question format allows the * character as a wildcard in expected answer for numerical subquestions.

**PR Type**
- Fix
