### PR TITLE
Fix877 - question_manually_graded exception divide by zero

### DIFF
--- a/src/transformer/events/mod_quiz/question_manually_graded.php
+++ b/src/transformer/events/mod_quiz/question_manually_graded.php
@@ -48,18 +48,24 @@ function question_manually_graded(array $config, \stdClass $event) {
     $user = $repo->read_record_by_id('user', $attempt->userid);
     $questionattempts = $repo->read_records(
         'question_attempts',
-        ['questionusageid' => (int) $attemptid],
+        ['questionusageid' => (int) $attempt->uniqueid],
     );
+    if (empty($questionattempts)) {
+        return [];
+    }
     $questionattempt = reset($questionattempts);
     $questionattemptsteps = $repo->read_records(
         'question_attempt_steps',
         ['questionattemptid' => $questionattempt->id],
         'sequencenumber DESC'
     );
+    if (empty($questionattemptsteps)) {
+        return [];
+    }
     $step = reset($questionattemptsteps);
-    $rawscore = (float) $step->fraction;
-    $minscore = (float) $questionattempt->minfraction;
-    $maxscore = (float) $questionattempt->maxfraction;
+    $rawscore = (float) ($step->fraction ?? 0);
+    $minscore = (float) ($questionattempt->minfraction ?? 0);
+    $maxscore = (float) ($questionattempt->maxfraction ?? 0);
 
     return [[
         'actor' => utils\get_user($config, $user),

--- a/src/transformer/utils/get_scaled_score.php
+++ b/src/transformer/utils/get_scaled_score.php
@@ -36,5 +36,8 @@ namespace src\transformer\utils;
  * @return int
  */
 function get_scaled_score($rawscore, $minscore, $maxscore) {
+    if ($maxscore == $minscore) {
+        return 0;
+    }
     return (($rawscore - $minscore) / ($maxscore - $minscore) * 2) - 1;
 }

--- a/tests/mod_quiz/question_manually_graded/data.json
+++ b/tests/mod_quiz/question_manually_graded/data.json
@@ -30,6 +30,7 @@
   "quiz_attempts": [
     {
       "id": 1,
+      "uniqueid": 1,
       "userid": 2,
       "quiz": 1,
       "state": "finished",


### PR DESCRIPTION
Fix for issue #877 

- resolved divide by zero issue - returns early if question_attempts or question_attempt_steps are empty.
- added $attempt->uniqueid to test data