### PR TITLE
switch to isset rather than empty

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -117,17 +117,17 @@ class store extends php_obj implements log_writer {
             $where[] = 'objectid IS NULL';
         }
 
-        if (!empty($event->timecreated)) {
+        if (isset($event->timecreated) && $event->timecreated !== null) {
             $sqlparams['timecreated'] = $event->timecreated;
             $where[] = 'timecreated = :timecreated';
         }
 
-        if (!empty($event->userid)) {
+        if (isset($event->userid) && $event->userid !== null) {
             $sqlparams['userid'] = $event->userid;
             $where[] = 'userid = :userid';
         }
 
-        if (!empty($event->anonymous)) {
+        if (isset($event->anonymous) && $event->anonymous !== null) {
             $sqlparams['anonymous'] = $event->anonymous;
             $where[] = 'anonymous = :anonymous';
         }


### PR DESCRIPTION
The fix changes three fields from !empty() to isset() && !== null:

- userid (line 125) — The main bug. userid = 0 (system/guest events) was being dropped from the WHERE clause, causing MAX(id) to match wrong log entries.
- anonymous (line 130) — anonymous = 0 (non-anonymous events) was also being silently dropped.
- timecreated (line 120) — Changed for consistency, though unlikely to be 0 in practice.

The string fields (eventname, component, action, target) are fine with !empty() since they should never legitimately be "0". The objecttable/objectid fields already have explicit else branches handling the null/empty case.