### PR TITLE
Feat: add OAuth2 authentication option to LRS

### DIFF
--- a/classes/log/store.php
+++ b/classes/log/store.php
@@ -282,6 +282,8 @@ class store extends php_obj implements log_writer {
             ],
             'loader' => [
                 'loader' => 'moodle_curl_lrs',
+                'oauth2_enabled' => $this->get_config('oauth2_enabled', ''),
+                'oauth2_token_endpoint' => $this->get_config('oauth2_token_endpoint', ''),
                 'lrs_endpoint' => $this->get_config('endpoint', ''),
                 'lrs_username' => $this->get_config('username', ''),
                 'lrs_password' => $this->get_config('password', ''),

--- a/lang/en/logstore_xapi.php
+++ b/lang/en/logstore_xapi.php
@@ -102,6 +102,13 @@ $string['noerrorsfound'] = 'No errors found';
 $string['norows'] = "No rows to report";
 $string['notificationsnotenabled'] = "Notifications not enabled";
 $string['notificationtriggerlimitnotreached'] = "Notification trigger limit not reached";
+$string['oauth2_token_endpoint'] = 'OAuth2 identity provider token endpoint';
+$string['oauth2_enabled'] = 'OAuth2 identity provider token endpoint';
+$string['oauth2_enabled_desc'] = 'When enabled,
+        connect to the OAuth2 identity provider using Username/password as ClientID/client secret
+        and the Client Credentials flow to get an auth token.
+        This token is then used to authenticate to the LRS.
+        Disable this option to connect to the LRS using Basic Auth';
 $string['password'] = 'LRS auth secret';
 $string['pluginadministration'] = 'Logstore xAPI administration';
 $string['pluginname'] = 'Logstore xAPI';

--- a/settings.php
+++ b/settings.php
@@ -87,6 +87,17 @@ if ($hassiteconfig) {
     $passwordsetting->size = 40;
     $settings->add($passwordsetting);
 
+    $settings->add(new admin_setting_configcheckbox(
+        'logstore_xapi/oauth2_enabled',
+        get_string('oauth2_enabled', 'logstore_xapi'),
+        get_string('oauth2_enabled_desc', 'logstore_xapi'), 1)
+    );
+    $settings->add(new admin_setting_configtext(
+        'logstore_xapi/oauth2_token_endpoint',
+        get_string('oauth2_token_endpoint', 'logstore_xapi'), '',
+        'https://auth.example.com/oauth/token', PARAM_URL)
+    );
+
     // Processing and batches.
     $settings->add(new admin_setting_heading(
         'processingbatches',

--- a/src/loader/lrs.php
+++ b/src/loader/lrs.php
@@ -40,9 +40,27 @@ function load(array $config, array $events) {
         $endpoint = $config['lrs_endpoint'];
         $username = $config['lrs_username'];
         $password = $config['lrs_password'];
+        $oauth2_enabled = $config['oauth2_enabled'];
+        $oauth2_token_endpoint = $config['oauth2_token_endpoint'];
 
+        if ($oauth2_enabled) {
+          $oauth2_token_set = array_key_exists('oauth2_token_cached', $config);
+          $oauth2_token_expired = true;
+          if ($oauth2_token_set) {
+            $oauth2_token_cached_expiry = (int)$config['oauth2_token_cached_expiry'];
+            $oauth2_token_expired = $oauth2_token_cached_expiry - time() < 300;
+          }
+          if ($oauth2_token_expired) {
+            $oauth2_token_data = utils\get_oauth2_token($oauth2_token_endpoint, $username, $password);
+            $config['oauth2_token_cached'] = $oauth2_token_data['access_token'];
+            $config['oauth2_token_cached_expiry'] = time() + (int)$oauth2_token_data['expires_in'];
+          }
+          $auth_header = 'Bearer ' . $config['oauth2_token_cached']; 
+        }
+        else {
+          $auth_header = 'Basic ' . base64_encode($username . ':' . $password);
+        }
         $url = utils\correct_endpoint($endpoint) . '/statements';
-        $auth = base64_encode($username . ':' . $password);
         $postdata = json_encode($statements);
 
         if ($postdata === false) {
@@ -55,14 +73,13 @@ function load(array $config, array $events) {
         curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($request, CURLOPT_HTTPHEADER, [
-            'Authorization: Basic ' . $auth,
+            'Authorization: ' . $auth_header,
             'X-Experience-API-Version: 1.0.3',
             'Content-Type: application/json',
         ]);
 
         $responsetext = curl_exec($request);
         $responsecode = curl_getinfo($request, CURLINFO_RESPONSE_CODE);
-        curl_close($request);
 
         if ($responsecode !== 200) {
             throw new \Exception($responsetext, $responsecode);

--- a/src/loader/moodle_curl_lrs.php
+++ b/src/loader/moodle_curl_lrs.php
@@ -48,9 +48,27 @@ function load(array $config, array $events) {
         $endpoint = $config['lrs_endpoint'];
         $username = $config['lrs_username'];
         $password = $config['lrs_password'];
+        $oauth2_enabled = $config['oauth2_enabled'];
+        $oauth2_token_endpoint = $config['oauth2_token_endpoint'];
 
+        if ($oauth2_enabled) {
+          $oauth2_token_set = array_key_exists('oauth2_token_cached', $config);
+          $oauth2_token_expired = true;
+          if ($oauth2_token_set) {
+            $oauth2_token_cached_expiry = (int)$config['oauth2_token_cached_expiry'];
+            $oauth2_token_expired = $oauth2_token_cached_expiry - time() < 300;
+          }
+          if ($oauth2_token_expired) {
+            $oauth2_token_data = utils\get_oauth2_token($oauth2_token_endpoint, $username, $password);
+            $config['oauth2_token_cached'] = $oauth2_token_data['access_token'];
+            $config['oauth2_token_cached_expiry'] = time() + (int)$oauth2_token_data['expires_in'];
+          }
+          $auth_header = 'Bearer ' . $config['oauth2_token_cached']; 
+        }
+        else {
+          $auth_header = 'Basic ' . base64_encode($username . ':' . $password);
+        }
         $url = utils\correct_endpoint($endpoint) . '/statements';
-        $auth = base64_encode($username . ':' . $password);
         $postdata = json_encode($statements);
 
         if ($postdata === false) {
@@ -63,7 +81,7 @@ function load(array $config, array $events) {
         curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($request, CURLOPT_HTTPHEADER, [
-            'Authorization: Basic ' . $auth,
+            'Authorization: ' . $auth_header,
             'X-Experience-API-Version: 1.0.3',
             'Content-Type: application/json',
         ]);

--- a/src/loader/utils/get_oauth2_token.php
+++ b/src/loader/utils/get_oauth2_token.php
@@ -1,0 +1,64 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Adjusts the endpoint to the appropriate place.
+ *
+ * @package   logstore_xapi
+ * @copyright Jerret Fowler <jerrett.fowler@gmail.com>
+ *            Ryan Smith <https://www.linkedin.com/in/ryan-smith-uk/>
+ *            David Pesce <david.pesce@exputo.com>
+ * @license   https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace src\loader\utils;
+
+/**
+ * Get an OAuth2 token from provided IdP using Client Credentials flow.
+ * The Client ID and secrets are base-64-encoded in a Basic auth header. 
+ *
+ * @param string $token_endpoint The 'token' http endpoint of the OAuth2 IdP
+ * @param string $client_id The client ID of this Moodle instance in the IdP
+ * @param string $client_secret The client secret of this Moodle instance in the IdP 
+ * @return array token data in JSON
+ *                {"access_token": ..., "expires_in": ..., "scope": ..., "token_type": ... }
+ * }
+ *              
+ */
+function get_oauth2_token(string $token_endpoint, string $client_id, string $client_secret) {
+    $auth_header = 'Basic ' . base64_encode($client_id . ':' . $client_secret);
+
+    $request = curl_init();
+    curl_setopt($request, CURLOPT_POST, 1);
+    curl_setopt($request, CURLOPT_URL, $token_endpoint);
+    curl_setopt($request, CURLOPT_POSTFIELDS, "grant_type=client_credentials");
+    curl_setopt($request, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($request, CURLOPT_SSL_VERIFYPEER, false);
+    curl_setopt($request, CURLOPT_HTTPHEADER, [
+        'Authorization: ' . $auth_header,
+        'content-type: application/x-www-form-urlencoded',
+        'Accept: application/json'
+    ]);
+
+    $responsetext = curl_exec($request);
+    $responsecode = curl_getinfo($request, CURLINFO_RESPONSE_CODE);
+
+      if ($responsecode !== 200) {
+          throw new \Exception($responsetext, $responsecode);
+      }
+    
+    return json_decode($responsetext, true);
+}


### PR DESCRIPTION
**Description**
- Add support for OAuth2 authentication to the LRS
  - using the Client Credentials flow and `client_secret_basic` method.
  - using the `username` and `password` as Client ID and Client secret respectively.
- Add option to set an Identity Provider token endpoint.
- Add a switch for OAuth2/Basic auth.

**PR Type**
- Enhancement
